### PR TITLE
👷‍♀️ Bump version of github workflow runner

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   validate:
     name: Validate Implementation Guide
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: [10, 12]

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     name: 📝 Preview Implementation Guide
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: 👩‍💻 Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish:
     name: Publish Implementation Guide
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: [10, 12]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     if: github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'release')
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Manual workaround for Github not having a runtime macro to check for the default branch
         id: gatekeeper


### PR DESCRIPTION
@RobertJCarroll noticed that the Jekyll install started failing and that our Ubuntu image version is deprecated. 

The Jekyll install was failing due to the Ruby version being too low. Instead of bumping up the Ruby version, I've bumped up the version of Ubuntu that the Github workflow runs on from 18.04 to 20.04.

This solves two problems: 1) Jekyll installs successfully and 2) it ensures that we are not using a deprecated Ubuntu image (18.04 is deprecated and being phased out).

