### PR TITLE
Removed link that pointed to file that ultimately was deleted

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -41,7 +41,6 @@ menu:
     Modular IG Overview: modular_ig.html
     Research Study: research_study.html
     Study Metadata: study_metadata.html
-    Study Summary: study_summary.html
     Raw Data: raw_data.html
     Participant-level Data: participant.html
     Assays and File Data: files.html

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -41,7 +41,6 @@ menu:
     Modular IG Overview: modular_ig.html
     Research Study: research_study.html
     Study Metadata: study_metadata.html
-    Raw Data: raw_data.html
     Participant-level Data: participant.html
     Assays and File Data: files.html
     Generic Tabular Data: tabular.html


### PR DESCRIPTION
I moved the "study summary" details into the "study metadata" but forgot to remove it from the menu. 