### PR TITLE
Fixes required to deploy jenkins and sushi

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   validate:
     name: Validate Implementation Guide
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [10, 12]
@@ -19,7 +19,7 @@ jobs:
       - name: Set up OpenJDK
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
 
       - name: Set up Jekyll
         run: |
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install SUSHI and add FSH definitions
         run: |
-          npm install -g fsh-sushi
+          npm install -g fsh-sushi@^2.10.2
           sushi .
 
       - name: Update IG publisher

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     name: 📝 Preview Implementation Guide
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: 👩‍💻 Checkout code
         uses: actions/checkout@v3
@@ -15,7 +15,7 @@ jobs:
       - name: 🛠 Set up OpenJDK
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
 
       - name: 🛠 Set up Jekyll
         run: |
@@ -30,7 +30,7 @@ jobs:
 
       - name: 🛠 Install SUSHI and add FSH definitions
         run: |
-          npm install -g fsh-sushi
+          npm install -g fsh-sushi@^2.10.2
           sushi .
 
       - name: ⬆️ Update IG publisher

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   publish:
     name: Publish Implementation Guide
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [10, 12]
@@ -21,7 +21,7 @@ jobs:
       - name: Set up OpenJDK
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
 
       - name: Set up Jekyll
         run: |
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install SUSHI and add FSH definitions
         run: |
-          npm install -g fsh-sushi
+          npm install -g fsh-sushi@^2.10.2
           sushi .
 
       - name: Update IG publisher

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     if: github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'release')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Manual workaround for Github not having a runtime macro to check for the default branch
         id: gatekeeper


### PR DESCRIPTION
Ruby 2.7 isn't supported by the current version of one of Jenkin's dependencies, so I have migrated us up to the current long term ubuntu release. Also, the current version of publisher required a newer version of java-so I've bumped that up as well. Finally, our FSH files are not compatible with sushi 3.x, so I've updated the npm command to stick with 2.